### PR TITLE
Added a "progress" event to relay the game's asset preloading progress.

### DIFF
--- a/src/container/Container.js
+++ b/src/container/Container.js
@@ -216,6 +216,7 @@
 		this.client.on(
 		{
 			loading: onLoading.bind(this),
+			progress: onProgress.bind(this),
 			loadDone: onLoadDone.bind(this), // @deprecated use 'loaded' instead
 			loaded: onLoadDone.bind(this),
 			endGame: onEndGame.bind(this),
@@ -256,11 +257,27 @@
 	var onLoading = function()
 	{
 		/**
-		 * Event when a application start loading, first even received
+		 * Event when a application start loading, first event received
 		 * from the Application.
 		 * @event opening
 		 */
 		this.trigger('opening');
+	};
+
+	/**
+	 * The game preload is progressing
+	 * @method onProgress
+	 * @private
+	 * @param  {Event} event Bellhop event
+	 */
+	var onProgress = function(event)
+	{
+		/**
+		 * Event listing how many assets have loaded as the application loads.
+		 * @event progress
+		 * @param {Number} percentage The amount loaded from 0 to 1
+		 */
+		this.trigger('progress', event.data);
 	};
 
 	/**


### PR DESCRIPTION
I want to propose relaying "progress" events from the game to the container. I think it makes sense to add this functionality so that the hosting page / container knows the progress of the game load. For example, this allows the container to display a loading animation, progress bar, or related behavior while the game performs its initial load.

This can be handled already by creating the "progress" relay in a given game and then handling it in the container's JavaScript, but by providing the connection in SpringRoll and SpringRollContainer, the connected behavior needn't be hand-coded for each game on a given site.

Related SpringRoll pull request: https://github.com/SpringRoll/SpringRoll/pull/106