### PR TITLE
passing along the err object to allow for better error messaging

### DIFF
--- a/src/container/plugins/RemotePlugin.js
+++ b/src/container/plugins/RemotePlugin.js
@@ -75,7 +75,7 @@
 						this._internalOpen(release.url + options.query, options);
 					}
 					.bind(this))
-				.fail(function()
+				.fail(function(err)
 					{
 						if (this._destroyed) return;
 
@@ -83,7 +83,7 @@
 						 * Fired when the API cannot be called
 						 * @event remoteFailed
 						 */
-						return this.trigger('remoteFailed');
+						return this.trigger('remoteFailed', err);
 					}
 					.bind(this));
 		};


### PR DESCRIPTION
this err object will be used in springroll connect for api error messages