### PR TITLE
add license to bower.json:

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
 		"google-code-prettify": "*",
 		"bind-polyfill": "*"
 	},
+	"license": "MIT",	
 	"ignore": [
 		".bowerrc",
 		".editorconfig",


### PR DESCRIPTION
issue: bower.json does not contain a license property #7