### PR TITLE
Getting tests running properly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
 	"devDependencies":
 	{
 		"easeljs": "https://github.com/SpringRoll/EaselJS.git",
-		"qunit": "*",
+		"qunit": "2.6.*",
 		"springroll": "*",
 		"google-code-prettify": "*",
 		"bind-polyfill": "*"

--- a/test/index.html
+++ b/test/index.html
@@ -10,6 +10,8 @@
 	<div id="qunit"></div>
 	<div id="qunit-fixture"></div>
 
+    <iframe id="frame"></iframe>
+
 	<!-- Unit testing dependencies -->
 	<script src="../components/bind-polyfill/index.js"></script>
 	<script src="../components/qunit/qunit/qunit.js"></script>
@@ -22,13 +24,12 @@
 	<script src="../dist/container.js"></script>
 
 	<script>
-	test('Container Test', function(assert)
+	QUnit.test('Container Test', function(assert)
 	{
-		expect(1);
 		var Container = include('springroll.Container');
-		var container = new Container();
+		var container = new Container('#frame');
 		container.destroy();
-		assert.ok(true, "Created a container");
+		QUnit.assert.ok(true, "Created a container");
 	});
 	</script>
 </body>


### PR DESCRIPTION
QUnit had changed a lot since the tests were last written. Locking
version of QUnit, and then refactored tests to match the latest