### PR TITLE
Adding GitHub CI to release/1.1.4

### DIFF
--- a/.github/workflows/npm-deploy.yaml
+++ b/.github/workflows/npm-deploy.yaml
@@ -27,11 +27,6 @@ jobs:
         env:
           CI: true
 
-      # - name: test
-      #   run: npm run github-test
-      #   env:
-      #     CI: true
-
       - name: publish
         run: npm publish
         env:

--- a/.github/workflows/npm-deploy.yaml
+++ b/.github/workflows/npm-deploy.yaml
@@ -1,0 +1,39 @@
+name: npm-deploy
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://registry.npmjs.org/
+
+      - name: install
+        run: |
+          npm ci
+        env:
+          CI: true
+
+      - name: build
+        run: |
+          npm run build
+        env:
+          CI: true
+
+      # - name: test
+      #   run: npm run github-test
+      #   env:
+      #     CI: true
+
+      - name: publish
+        run: npm publish
+        env:
+          CI: true
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
I think this is going to be necessary, based on the error that I got when trying to trigger the workflow dispatch off the `release/1.1.4` branch. 

<img width="317" alt="Screen Shot 2021-04-23 at 13 04 28" src="https://user-images.githubusercontent.com/11247449/115906997-4784b200-a436-11eb-82ff-dd663411475b.png">
