### PR TITLE
Add manageOwnVisibility flag to pausePlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] unreleased
 
 ## [2.3.4] 2022-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.0] unreleased
 
+## Added
+
+- Added `manageOwnVisibility` flag to the PausePlugin to make turning off visibility/focus management easier
+
 ## [2.3.4] 2022-06-09
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ container.openPath('game.html');
 
 `PausePlugin` sets a className of 'paused' or 'unpaused' on individual pause buttons.
 
+The `PausePlugin` also has an optional flag
+`manageOwnVisibility`. This defaults to `true` and is intended to disable the visibility management of the plugin for environements
+that handle visibility/focus themselves. For most web based contexts this flag will not be needed.
+
+```javascript
+import { PausePlugin, Container } from 'springroll-container';
+
+const container = new Container("#game", {
+  plugins: [
+    // manageOwnVisibility is set to false which means the plugin will not send pause or unpause events if the app is no longer
+    // focused or other similar states (switched tabs, etc)
+    new PausePlugin('button#pause-button', false),
+  ]
+});
+container.openPath('game.html');
+```
+
 ### Captions
 
 There are two plugins that interact with captions: `CaptionsTogglePlugin`, and `CaptionsStylePlugin`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,12 +53,6 @@
             "minimist": "^1.2.0"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -3597,9 +3591,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
           "dev": true
         }
       }
@@ -3911,6 +3905,12 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -3942,9 +3942,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
           "dev": true
         }
       }

--- a/src/plugins/PausePlugin.spec.js
+++ b/src/plugins/PausePlugin.spec.js
@@ -44,6 +44,54 @@ describe('PausePlugin', () => {
     expect(pp.pauseButton[0].classList.contains('unpaused')).to.be.true;
   });
 
+  describe('manageOwnVisibility', () => {
+    let disabledPlugin;
+    before(() => {
+      const button = document.createElement('button');
+      document.body.innerHTML = '';
+      button.id = 'ignore';
+      document.body.appendChild(button);
+      disabledPlugin = new PausePlugin('#ignore', false); // disable the focus management of the plugin
+      disabledPlugin.preload({ client: new Bellhop() });
+    });
+
+    it('should set manageOwnVisibility to false', () => {
+      // control
+      expect(pp.manageOwnVisibility).to.be.true;
+
+      expect(disabledPlugin.manageOwnVisibility).to.be.false;
+    });
+
+    it('should set pageVisibility.enabled to false', () => {
+      expect(disabledPlugin.pageVisibility.enabled).to.be.false;
+    });
+
+    it('manageFocus() should not change pause state', async () => {
+      expect(disabledPlugin.pause).to.be.false;
+
+      disabledPlugin._containerBlurred = true;
+      disabledPlugin._appBlurred = true;
+
+      disabledPlugin.manageFocus();
+      await sleep(150);
+      expect(disabledPlugin.pause).to.be.false;
+    });
+
+    it('setting flag to true should re-enable everything', async () => {
+      disabledPlugin.manageOwnVisibility = true;
+
+      expect(disabledPlugin.pageVisibility.enabled).to.be.true;
+      disabledPlugin._containerBlurred = true;
+      disabledPlugin._appBlurred = true;
+
+      disabledPlugin.manageFocus();
+      await sleep(150);
+      expect(disabledPlugin.pause).to.be.true;
+    });
+
+
+  });
+
   describe('manageFocus()', () => {
     it('should set pause to false if only app is blurred', async () => {
       pp.onPauseToggle(); //reset the manual pause state which was being set to true for some reason.


### PR DESCRIPTION
It made more sense to me to add the flag directly to the pause plugin itself rather than Container because the feature isn't required unless you have the pausePlugin enabled. As well Container isn't actually aware of which plugins it has active so communication between the two (enabling or disabling the flag) was tricky. 