### PR TITLE
Adding missing manageOwnVisibility argument to the constructor of PausePlugin typing.

### DIFF
--- a/typings/plugins/PausePlugin.d.ts
+++ b/typings/plugins/PausePlugin.d.ts
@@ -2,7 +2,7 @@ import { ButtonPlugin } from '../base-plugins';
 import { Button } from '../ui-elements';
 import { PageVisibility } from '..'
 export class PausePlugin extends ButtonPlugin {
-  constructor(pauseButton: string);
+  constructor(pauseButton: string,manageOwnVisibility = true);
 
   _appBlurred: boolean;
   _containerBlurred: boolean;


### PR DESCRIPTION
This was throwing errors in TypeScript when trying to pass along the value.