### PR TITLE
Feature/184140047-Update gha workflow to not publish pre releases to npm

### DIFF
--- a/.github/workflows/npm-deploy.yaml
+++ b/.github/workflows/npm-deploy.yaml
@@ -2,7 +2,7 @@ name: npm-deploy
 
 on:
   release:
-    types: [created]
+    types: [released]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/184140047

This changes the workflow release type so it only executes when a full release is made.  It was previously set to "created", which also includes pre-releases.

Note, the ticket specifies that the node version should be updated to 16, however that change was already made as part of the Rollup update ticket: https://www.pivotaltracker.com/story/show/184415976 . I'll merge in that change once that PR has been approved.